### PR TITLE
Updated watcher

### DIFF
--- a/src/bin/watcher
+++ b/src/bin/watcher
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 ## watcher --start == will starts the process of making csv
 # watcher --daily-summary == will give you your day overview till that point


### PR DESCRIPTION
If there is no python3 it will throw errors in some linux systems where the user has not defaulted to python