### PR TITLE
switch to python3 in shebang

### DIFF
--- a/src/bin/watcher
+++ b/src/bin/watcher
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import sys


### PR DESCRIPTION
on debian #!/usr/bin/python links to python2 to help with stability of older packages. It also might be better to specify a python the python version anyways since it does not work with python2 no matter what distro you are on.