### PR TITLE
feat: add instructions to open terminal with watcher report to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,23 @@ $ bash <(curl -s https://raw.githubusercontent.com/Waishnav/Watcher/main/install
 $ chmod +x ./install && ./install
 ```
 
+### Display your screen time of the day in a terminal with automatic refresh
+
+On gnome:
+
+`gnome-terminal -- watch cat "/home/$(whoami)/.cache/Watcher/daily_data/$(date +%Y-%m-%d).csv"`
+
+On KDE:
+
+`konsole -e watch cat "/home/$(whoami)/.cache/Watcher/daily_data/$(date +%Y-%m-%d).csv"`
+
+On any other terminal, reuse the command `watch cat "/home/$(whoami)/.cache/Watcher/daily_data/$(date +%Y-%m-%d).csv"`
+
+This will assume that watcher is already started.
+You can add this script to your system's autostart config to have it open on login.
+
 ### Want to Contribute
-If you are interseted in contibuting checkout [CONTRIBUTING.md](https://github.com/Waishnav/Watcher/blob/main/CONTRIBUTING.md)
+If you are interested in contibuting checkout [CONTRIBUTING.md](https://github.com/Waishnav/Watcher/blob/main/CONTRIBUTING.md)
 
 You can currently contribute to one of the three projects listed below throughout the HACTOBERFEST. 
 - [Watcher Website](https://github.com/Waishnav/Watcher-web) (made with React)


### PR DESCRIPTION
Hi, nice project!
I was looking for a simple screen time / activity watcher (tried ActivityWatch which is great but recorded too much information and uploads files to a remote bucket which is a big no for me).

I updated your README for other people like me who want to open a terminal window with the content of today's activity refreshing automatically. Feel free to merge it (or close it if you think that's not useful).
(also fixed a typo if you don't mind)