### PR TITLE
Fix: Ubuntu/Mint compatibility patch (#37)

### DIFF
--- a/src/Watcher/analysis.py
+++ b/src/Watcher/analysis.py
@@ -6,7 +6,7 @@ import time_operations as to
 
 # creating dictionary to store time spend on each applicaitons on that particular day
 def final_report(date):
-    path = "/home/" + os.getlogin() +"/.cache/Watcher/daily_data/"
+    path = os.environ['HOME'] +"/.cache/Watcher/daily_data/"
     filename = path + date + ".csv"
 
     report = dict()
@@ -63,8 +63,8 @@ def weekday_from_date(date):
     return day[0:-1]
 
 def weekly_logs(week = str(os.popen('''date +"W%V-%Y"''').read()[0:-1])):
-    user = os.getlogin()
-    filename = "/home/"+user+"/.cache/Watcher/Analysis/"+week+".csv"
+    user = os.environ['HOME']
+    filename = user+"/.cache/Watcher/Analysis/"+week+".csv"
     with open(filename, "w") as csvfile:
         csvwriter = csv.writer(csvfile, delimiter='\t')
 

--- a/src/Watcher/commands.py
+++ b/src/Watcher/commands.py
@@ -71,8 +71,8 @@ def daily_summary(date = get_date()):
         print("   " + Color.GREEN(f'{x:<22}') + '\t ',f'{to.format_time(y):>12}')
 
 def week_summary(week = os.popen('''date +"W%V-%Y"''').read()[:-1]):
-    user = os.getlogin()
-    filename = "/home/"+user+"/.cache/Watcher/Analysis/"+week+".csv"
+    user = os.environ['HOME']
+    filename = user+"/.cache/Watcher/Analysis/"+week+".csv"
     with open(filename, 'r') as file:
         csvreader = csv.reader(file, delimiter='\t')
         week_overview = dict()

--- a/src/Watcher/get_windows.py
+++ b/src/Watcher/get_windows.py
@@ -30,13 +30,13 @@ def active_window():
     aw_title = active_window_title()
     terminals = ["Kitty", "Alacritty", "Terminator", "Tilda", "Guake", "Yakuake", "Roxterm", "Eterm", "Rxvt", "Xterm", "Tilix", "Lxterminal", "Konsole", "St", "Gnome-terminal", "Xfce4-terminal", "Terminology", "Extraterm", "Mate-terminal"]
     if active_window in terminals:
-        # We have a terminal open
-        if os.popen('pgrep -a -x -w vim').read() != '':
-            # We have a vim process running - assume that it's active
-            active_window = "Vim"
-        elif os.popen('pgrep -a -x -w nvim').read() != '':
-            # We have a neovim process running
-            active_window = "NeoVim"
+        try:
+            if "nvim" in aw_title:
+                active_window = "NeoVim"
+            elif "vim" in aw_title:
+                active_window = "Vim"
+        except TypeError:
+            None
     return active_window
 
 # returns true if user has move to next app which is not the same as previous

--- a/src/Watcher/get_windows.py
+++ b/src/Watcher/get_windows.py
@@ -32,7 +32,7 @@ def active_window():
     terminals = ["Kitty", "Alacritty", "Terminator", "Tilda", "Guake", "Yakuake", "Roxterm", "Eterm", "Rxvt", "Xterm", "Tilix", "Lxterminal", "Konsole", "St", "Gnome-terminal", "Xfce4-terminal", "Terminology", "Extraterm", "Mate-terminal"]
     if active_window in terminals:
         if os.popen('pgrep -a -x -w vim').read() != '':
-            vim_processes = os.popen("pgrep -a vim | grep -v embed | awk '{print $1}'").read().strip().split(' ')
+            vim_processes = os.popen("pgrep -a vim | grep -v embed | awk '{print $1}'").read().strip().split('\n')
             for vim_process in vim_processes:
                 if master_check(pid, vim_process):
                     active_window = "Vim"

--- a/src/Watcher/get_windows.py
+++ b/src/Watcher/get_windows.py
@@ -28,32 +28,16 @@ def active_window():
     # check whether user is using nvim or vim
     active_window = active_window.capitalize()
     aw_title = active_window_title()
-    pid = os.popen('xdotool getwindowpid $(xdotool getactivewindow)').read().strip()
     terminals = ["Kitty", "Alacritty", "Terminator", "Tilda", "Guake", "Yakuake", "Roxterm", "Eterm", "Rxvt", "Xterm", "Tilix", "Lxterminal", "Konsole", "St", "Gnome-terminal", "Xfce4-terminal", "Terminology", "Extraterm", "Mate-terminal"]
     if active_window in terminals:
+        # We have a terminal open
         if os.popen('pgrep -a -x -w vim').read() != '':
-            vim_processes = os.popen("pgrep -a vim | grep -v embed | awk '{print $1}'").read().strip().split('\n')
-            for vim_process in vim_processes:
-                if master_check(pid, vim_process):
-                    active_window = "Vim"
-        if os.popen('pgrep -a -x -w nvim').read() != '':
-            # Filter embed processes
-            nvim_processes = os.popen("pgrep -a nvim | grep -v embed | awk '{print $1}'").read().strip().split('\n')
-            for nvim_process in nvim_processes:
-                # Find match for master process
-                if master_check(pid, nvim_process):
-                    active_window = "NeoVim"
+            # We have a vim process running - assume that it's active
+            active_window = "Vim"
+        elif os.popen('pgrep -a -x -w nvim').read() != '':
+            # We have a neovim process running
+            active_window = "NeoVim"
     return active_window
-
-def master_check(master_process, process):
-    # Recursively check the master processes to confirm if master terminal is the active terminal
-    master = os.popen(f"ps -p {process} -o ppid=").read().strip()
-    if master != master_process and master != '':
-        return master_check(master_process, master)
-    elif master == '':
-        return False
-    else:
-        return True
 
 # returns true if user has move to next app which is not the same as previous
 def previous_window(array_of_window, active_window):

--- a/src/Watcher/get_windows.py
+++ b/src/Watcher/get_windows.py
@@ -28,16 +28,32 @@ def active_window():
     # check whether user is using nvim or vim
     active_window = active_window.capitalize()
     aw_title = active_window_title()
-    terminals = ["Kitty", "Alacritty", "Terminator", "Tilda", "Guake", "Yakuake", "Roxterm", "Eterm", "Rxvt", "Xterm", "Tilix", "Lxterminal", "Konsole", "St", "Gnome-terminal", "Xfce4-terminal", "Terminology", "Extraterm"]
+    pid = os.popen('xdotool getwindowpid $(xdotool getactivewindow)').read().strip()
+    terminals = ["Kitty", "Alacritty", "Terminator", "Tilda", "Guake", "Yakuake", "Roxterm", "Eterm", "Rxvt", "Xterm", "Tilix", "Lxterminal", "Konsole", "St", "Gnome-terminal", "Xfce4-terminal", "Terminology", "Extraterm", "Mate-terminal"]
     if active_window in terminals:
-        try:
-            if "nvim" in aw_title:
-                active_window = "NeoVim"
-            elif "vim" in aw_title:
-                active_window = "Vim"
-        except TypeError:
-            None
+        if os.popen('pgrep -a -x -w vim').read() != '':
+            vim_processes = os.popen("pgrep -a vim | grep -v embed | awk '{print $1}'").read().strip().split(' ')
+            for vim_process in vim_processes:
+                if master_check(pid, vim_process):
+                    active_window = "Vim"
+        if os.popen('pgrep -a -x -w nvim').read() != '':
+            # Filter embed processes
+            nvim_processes = os.popen("pgrep -a nvim | grep -v embed | awk '{print $1}'").read().strip().split('\n')
+            for nvim_process in nvim_processes:
+                # Find match for master process
+                if master_check(pid, nvim_process):
+                    active_window = "NeoVim"
     return active_window
+
+def master_check(master_process, process):
+    # Recursively check the master processes to confirm if master terminal is the active terminal
+    master = os.popen(f"ps -p {process} -o ppid=").read().strip()
+    if master != master_process and master != '':
+        return master_check(master_process, master)
+    elif master == '':
+        return False
+    else:
+        return True
 
 # returns true if user has move to next app which is not the same as previous
 def previous_window(array_of_window, active_window):

--- a/src/Watcher/watch_log.py
+++ b/src/Watcher/watch_log.py
@@ -16,7 +16,7 @@ def get_date():
     return d[0:-1]
 
 def update_csv(date, Data):
-    filename = "/home/"+os.getlogin()+"/.cache/Watcher/daily_data/"+date+".csv"
+    filename = os.environ['HOME']+"/.cache/Watcher/daily_data/"+date+".csv"
     overwrite_Data = []
     with open(filename, 'w') as csvfile:
         for x,y in Data.items():
@@ -43,9 +43,9 @@ def import_data(file):
 # TODO: AFK feature devlopement (it will be developed after completing alpha product (after whole project up end running)
 
 def log_creation():
-    filename = "/home/"+os.getlogin()+"/.cache/Watcher/daily_data/"+get_date()+".csv"
+    filename = os.environ['HOME']+"/.cache/Watcher/daily_data/"+get_date()+".csv"
     if not(os.path.isfile(filename)):
-        creat_file = "/home/"+os.getlogin()+"/.cache/Watcher/daily_data/"+get_date()+".csv"
+        creat_file = os.environ['HOME']+"/.cache/Watcher/daily_data/"+get_date()+".csv"
         with open(creat_file, 'w') as fp:
             pass
 
@@ -54,7 +54,7 @@ def log_creation():
     data = import_data(filename)
     while True:
         date = get_date()
-        filename = "/home/"+os.getlogin()+"/.cache/Watcher/daily_data/"+date+".csv"
+        filename = os.environ['HOME']+"/.cache/Watcher/daily_data/"+date+".csv"
         afk = y.is_afk(afkTimeout)
         print(data)
 
@@ -71,10 +71,10 @@ def log_creation():
 
             usage = time_addition("00:00:01", usage)
             data.update({active_window : usage})
-            if os.path.isfile("/home/"+os.getlogin()+"/.cache/Watcher/daily_data/"+get_date()+".csv"):
+            if os.path.isfile(os.environ['HOME']+"/.cache/Watcher/daily_data/"+get_date()+".csv"):
                 update_csv(get_date(), data)
-            elif not(os.path.isfile("/home/"+os.getlogin()+"/.cache/Watcher/daily_data/"+get_date()+".csv")):
-                new_filename = "/home/"+os.getlogin()+"/.cache/Watcher/daily_data/"+get_date()+".csv"
+            elif not(os.path.isfile(os.environ['HOME']+"/.cache/Watcher/daily_data/"+get_date()+".csv")):
+                new_filename = os.environ['HOME']+"/.cache/Watcher/daily_data/"+get_date()+".csv"
                 with open(new_filename, 'w') as fp:
                     pass
 


### PR DESCRIPTION
In addition to the OSError when getting the cache path, the NeoVim detection did not work on Linux Mint due to the way the terminal name is handled.

1. Changed `'/home/' + os.getlogin()` to `os.environ['HOME']` in all relevant files
2. Added Mate-terminal as a candidate for a linux terminal in the get_window.py script