### PR TITLE
removed the extra "$" in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ Funfact: You might be thinking how can someone has 14 hrs of screen time in a si
 - First, Install the following dependancy `xprintidle` and `xdotool`
 
 ```bash
-$ sudo [package-manager] install xprintidle xdotool
+```
+```sudo [package-manager] install xprintidle xdotool
 ```
 
 - Second, Copy the Following Command and paste in terminal
 
 ```bash
-$ bash <(curl -s https://raw.githubusercontent.com/Waishnav/Watcher/main/install)
+```
+```bash <(curl -s https://raw.githubusercontent.com/Waishnav/Watcher/main/install)
 ```
 
 - Then run install script

--- a/README.md
+++ b/README.md
@@ -35,15 +35,13 @@ Funfact: You might be thinking how can someone has 14 hrs of screen time in a si
 - First, Install the following dependancy `xprintidle` and `xdotool`
 
 ```bash
-```
-```sudo [package-manager] install xprintidle xdotool
+ sudo [package-manager] install xprintidle xdotool
 ```
 
 - Second, Copy the Following Command and paste in terminal
 
 ```bash
-```
-```bash <(curl -s https://raw.githubusercontent.com/Waishnav/Watcher/main/install)
+ bash <(curl -s https://raw.githubusercontent.com/Waishnav/Watcher/main/install)
 ```
 
 - Then run install script

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Funfact: You might be thinking how can someone has 14 hrs of screen time in a si
  sudo [package-manager] install xprintidle xdotool
 ```
 
-- Second, Copy the Following Command and paste in terminal
+- Second, Download the install script
 
 ```bash
- bash <(curl -s https://raw.githubusercontent.com/Waishnav/Watcher/main/install)
+ curl -s https://raw.githubusercontent.com/Waishnav/Watcher/main/install -o install
 ```
 
-- Then run install script
+- Third, Run the install script
 
 ```bash
  chmod +x ./install && ./install

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Funfact: You might be thinking how can someone has 14 hrs of screen time in a si
 - Then run install script
 
 ```bash
-$ chmod +x ./install && ./install
+ chmod +x ./install && ./install
 ```
 
 ### Want to Contribute


### PR DESCRIPTION
The $ sign in the readme.md was very much nonsensical and unnecessary. So whenever one would copy the commands, the extra $ would also get copied causing an annoying error in the command in terminal. I removed that.

Before:
<img width="869" height="284" alt="Screenshot_20260131_114435" src="https://github.com/user-attachments/assets/8f0646e7-43cf-442a-9418-7b6b940d351a" />

After:
<img width="869" height="284" alt="Screenshot_20260131_114534" src="https://github.com/user-attachments/assets/85334c72-b4c4-4d2c-82fd-fbc6593672e4" />
